### PR TITLE
PlaceholderTextColor and  backgroundTintColor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/AutoSuggestBox.cs
+++ b/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/AutoSuggestBox.cs
@@ -25,7 +25,7 @@ namespace dotMorten.Xamarin.Forms
     /// has been changed by the user and is responsible for providing relevant suggestions for this control to display.
     /// Use the UWP Reference doc for more information: <a href="https://msdn.microsoft.com/en-us/library/windows/apps/mt280217.aspx">Link</a>
     /// </summary>
-	public partial class AutoSuggestBox : View
+    public partial class AutoSuggestBox : View
     {
 #if !NETSTANDARD2_0
         internal NativeAutoSuggestBox NativeAutoSuggestBox { get; }
@@ -35,7 +35,7 @@ namespace dotMorten.Xamarin.Forms
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoSuggestBox"/> class
         /// </summary>
-        public AutoSuggestBox() 
+        public AutoSuggestBox()
         {
 #if !NETSTANDARD2_0
             NativeAutoSuggestBox = new NativeAutoSuggestBox(
@@ -59,7 +59,7 @@ namespace dotMorten.Xamarin.Forms
         /// <inheritdoc />
         protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
-            if(propertyName == nameof(IsEnabled))
+            if (propertyName == nameof(IsEnabled))
             {
 #if NETFX_CORE
                 NativeAutoSuggestBox.IsEnabled = IsEnabled;
@@ -105,7 +105,7 @@ namespace dotMorten.Xamarin.Forms
         /// <seealso cref="Text"/>
         public global::Xamarin.Forms.Color TextColor
         {
-            get { return (global::Xamarin.Forms.Color )GetValue(TextColorProperty); }
+            get { return (global::Xamarin.Forms.Color)GetValue(TextColorProperty); }
             set { SetValue(TextColorProperty, value); }
         }
 
@@ -113,7 +113,7 @@ namespace dotMorten.Xamarin.Forms
         /// Identifies the <see cref="TextColor"/> bindable property.
         /// </summary>
         public static readonly BindableProperty TextColorProperty =
-            BindableProperty.Create(nameof(TextColor), typeof(global::Xamarin.Forms.Color ), typeof(AutoSuggestBox), global::Xamarin.Forms.Color.Gray, BindingMode.OneWay, null, OnTextColorPropertyChanged);
+            BindableProperty.Create(nameof(TextColor), typeof(global::Xamarin.Forms.Color), typeof(AutoSuggestBox), global::Xamarin.Forms.Color.Gray, BindingMode.OneWay, null, OnTextColorPropertyChanged);
 
         private static void OnTextColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
@@ -125,8 +125,6 @@ namespace dotMorten.Xamarin.Forms
             box.NativeAutoSuggestBox.SetTextColor(color);
 #endif
         }
-
-
 
         /// <summary>
         /// Gets or sets the PlaceholderText
@@ -148,6 +146,114 @@ namespace dotMorten.Xamarin.Forms
             var box = (AutoSuggestBox)bindable;
 #if !NETSTANDARD2_0
             box.NativeAutoSuggestBox.PlaceholderText = newValue as string;
+#endif
+        }
+
+        /// <summary>
+        /// Gets or sets the color of the place holder text.
+        /// </summary>
+        /// <value>
+        /// The color of the place holder text.
+        /// </value>
+        public global::Xamarin.Forms.Color PlaceHolderTextColor
+        {
+            get { return (global::Xamarin.Forms.Color)GetValue(PlaceHolderColorProperty); }
+            set { SetValue(PlaceHolderColorProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="PlaceHolderTextColor"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty PlaceHolderColorProperty =
+            BindableProperty.Create(nameof(PlaceHolderTextColor), typeof(global::Xamarin.Forms.Color), typeof(AutoSuggestBox), global::Xamarin.Forms.Color.Gray, BindingMode.OneWay, null, OnPlaceHolderTextColorPropertyChanged);
+
+        private static void OnPlaceHolderTextColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var box = (AutoSuggestBox)bindable;
+            var color = (global::Xamarin.Forms.Color)newValue;
+#if NETFX_CORE
+            box.NativeAutoSuggestBox.Foreground = new Windows.UI.Xaml.Media.SolidColorBrush(Windows.UI.Color.FromArgb((byte)(color.A * 255), (byte)(color.R * 255), (byte)(color.G * 255), (byte)(color.B * 255)));
+#elif __ANDROID__ || __IOS__
+            box.NativeAutoSuggestBox.SetPlaceHolderTextColor(color);
+#endif
+        }
+
+        /// <summary>
+        /// Gets or sets the PlaceholderText
+        /// </summary>
+        public string PlaceholderText
+        {
+            get { return (string)GetValue(PlaceholderTextProperty); }
+            set { SetValue(PlaceholderTextProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="PlaceholderText"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty PlaceholderTextProperty =
+            BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(AutoSuggestBox), "", BindingMode.OneWay, null, OnPlaceholderTextPropertyChanged);
+
+        private static void OnPlaceholderTextPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            AutoSuggestBox box = (AutoSuggestBox)bindable;
+#if !NETSTANDARD2_0
+            box.NativeAutoSuggestBox.PlaceholderText = newValue as string;
+#endif
+        }
+
+        /// <summary>
+        /// Gets or sets the PlaceholderText
+        /// </summary>
+        public global::Xamarin.Forms.Color BackgroundTintList
+        {
+            get { return (global::Xamarin.Forms.Color)GetValue(BackgroundTintListProperty); }
+            set { SetValue(BackgroundTintListProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="BackgroundTintList"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty BackgroundTintListProperty =
+            BindableProperty.Create(nameof(BackgroundTintList), typeof(Color), typeof(AutoSuggestBox), global::Xamarin.Forms.Color.Gray, BindingMode.OneWay, null, OnBackgroundTintListPropertyChanged);
+
+        private static void OnBackgroundTintListPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            AutoSuggestBox box = (AutoSuggestBox)bindable;
+            Color color = (global::Xamarin.Forms.Color)newValue;
+
+            // TODO NETFX_CORE if required
+#if NETFX_CORE
+           
+#elif __ANDROID__
+            box.NativeAutoSuggestBox.SetBackgroundTintList(color);
+#endif
+        }
+
+        /// <summary>
+        /// Gets or sets the PlaceholderTexts
+        /// </summary>
+        private global::Xamarin.Forms.Color FocusOnBackgroundTintList
+        {
+            get { return (global::Xamarin.Forms.Color)GetValue(FocusOnBackgroundTintListProperty); }
+            set { SetValue(FocusOnBackgroundTintListProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="FocusOnBackgroundTintList"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty FocusOnBackgroundTintListProperty =
+            BindableProperty.Create(nameof(FocusOnBackgroundTintList), typeof(Color), typeof(AutoSuggestBox), global::Xamarin.Forms.Color.Gray, BindingMode.OneWay, null, OnFocusOnBackgroundTintListPropertyChanged);
+
+        private static void OnFocusOnBackgroundTintListPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            AutoSuggestBox box = (AutoSuggestBox)bindable;
+            var color = (global::Xamarin.Forms.Color)newValue;
+
+            // TODO NETFX_CORE if required
+#if NETFX_CORE
+           
+#elif __ANDROID__
+            box.NativeAutoSuggestBox.SetOnFocusTintBackgroundColor(color);
 #endif
         }
 

--- a/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/AutoSuggestBox.cs
+++ b/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/AutoSuggestBox.cs
@@ -127,29 +127,6 @@ namespace dotMorten.Xamarin.Forms
         }
 
         /// <summary>
-        /// Gets or sets the PlaceholderText
-        /// </summary>
-        public string PlaceholderText
-        {
-            get { return (string)GetValue(PlaceholderTextProperty); }
-            set { SetValue(PlaceholderTextProperty, value); }
-        }
-
-        /// <summary>
-        /// Identifies the <see cref="PlaceholderText"/> bindable property.
-        /// </summary>
-        public static readonly BindableProperty PlaceholderTextProperty =
-            BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(AutoSuggestBox), "", BindingMode.OneWay, null, OnPlaceholderTextPropertyChanged);
-
-        private static void OnPlaceholderTextPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            var box = (AutoSuggestBox)bindable;
-#if !NETSTANDARD2_0
-            box.NativeAutoSuggestBox.PlaceholderText = newValue as string;
-#endif
-        }
-
-        /// <summary>
         /// Gets or sets the color of the place holder text.
         /// </summary>
         /// <value>
@@ -191,12 +168,14 @@ namespace dotMorten.Xamarin.Forms
         /// Identifies the <see cref="PlaceholderText"/> bindable property.
         /// </summary>
         public static readonly BindableProperty PlaceholderTextProperty =
-            BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(AutoSuggestBox), "", BindingMode.OneWay, null, OnPlaceholderTextPropertyChanged);
+            BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(AutoSuggestBox), string.Empty, BindingMode.OneWay, null, OnPlaceholderTextPropertyChanged);
 
         private static void OnPlaceholderTextPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             AutoSuggestBox box = (AutoSuggestBox)bindable;
 #if !NETSTANDARD2_0
+            box.NativeAutoSuggestBox.PlaceholderText = newValue as string;
+#elif __ANDROID__ ||  __IOS__
             box.NativeAutoSuggestBox.PlaceholderText = newValue as string;
 #endif
         }
@@ -230,9 +209,9 @@ namespace dotMorten.Xamarin.Forms
         }
 
         /// <summary>
-        /// Gets or sets the PlaceholderTexts
+        /// Gets or sets the PlaceholderText
         /// </summary>
-        private global::Xamarin.Forms.Color FocusOnBackgroundTintList
+        public global::Xamarin.Forms.Color FocusOnBackgroundTintList
         {
             get { return (global::Xamarin.Forms.Color)GetValue(FocusOnBackgroundTintListProperty); }
             set { SetValue(FocusOnBackgroundTintListProperty, value); }

--- a/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.Android.cs
+++ b/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.Android.cs
@@ -59,6 +59,40 @@ namespace dotMorten.Xamarin.Forms
             set => HintFormatted = new Java.Lang.String(value as string ?? "");
         }
 
+        private Android.Graphics.Color tintBackgroundColor;
+
+        public void SetBackgroundTintList(global::Xamarin.Forms.Color color)
+        {
+            tintBackgroundColor = global::Xamarin.Forms.Platform.Android.ColorExtensions.ToAndroid(color);
+
+               if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Lollipop)
+                this.BackgroundTintList = Android.Content.Res.ColorStateList.ValueOf(global::Xamarin.Forms.Platform.Android.ColorExtensions.ToAndroid(color));
+            else
+                this.Background.SetColorFilter(global::Xamarin.Forms.Platform.Android.ColorExtensions.ToAndroid(color), Android.Graphics.PorterDuff.Mode.SrcAtop);
+        }
+
+        public Android.Graphics.Color onFocusTintBackgroundColor { get; private set; }
+
+        public void SetOnFocusTintBackgroundColor(global::Xamarin.Forms.Color color)
+        {
+           onFocusTintBackgroundColor = global::Xamarin.Forms.Platform.Android.ColorExtensions.ToAndroid(color);
+
+            this.FocusChange += Control_FocusChange;
+        }
+
+        private void Control_FocusChange(object sender, Android.Views.View.FocusChangeEventArgs e)
+        {
+                if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Lollipop)
+                    this.BackgroundTintList = Android.Content.Res.ColorStateList.ValueOf(e.HasFocus != null ? onFocusTintBackgroundColor : Android.Graphics.Color.Green);
+                else
+                    this.Background.SetColorFilter(e.HasFocus ? onFocusTintBackgroundColor : Android.Graphics.Color.Green, Android.Graphics.PorterDuff.Mode.SrcAtop); 
+        }
+
+        public void SetPlaceHolderTextColor(global::Xamarin.Forms.Color color)
+        {
+            this.SetHintTextColor(global::Xamarin.Forms.Platform.Android.ColorExtensions.ToAndroid(color));
+        }
+
         public bool IsSuggestionListOpen
         {
             set

--- a/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.Android.cs
+++ b/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.Android.cs
@@ -54,11 +54,6 @@ namespace dotMorten.Xamarin.Forms
             this.SetTextColor(global::Xamarin.Forms.Platform.Android.ColorExtensions.ToAndroid(color));
         }
 
-        public string PlaceholderText
-        {
-            set => HintFormatted = new Java.Lang.String(value as string ?? "");
-        }
-
         private Android.Graphics.Color tintBackgroundColor;
 
         public void SetBackgroundTintList(global::Xamarin.Forms.Color color)
@@ -86,6 +81,12 @@ namespace dotMorten.Xamarin.Forms
                     this.BackgroundTintList = Android.Content.Res.ColorStateList.ValueOf(e.HasFocus != null ? onFocusTintBackgroundColor : Android.Graphics.Color.Green);
                 else
                     this.Background.SetColorFilter(e.HasFocus ? onFocusTintBackgroundColor : Android.Graphics.Color.Green, Android.Graphics.PorterDuff.Mode.SrcAtop); 
+        }
+
+        public string PlaceholderText
+        {
+            get => base.HintFormatted.ToString();
+            set => HintFormatted = new Java.Lang.String(value as string ?? "");
         }
 
         public void SetPlaceHolderTextColor(global::Xamarin.Forms.Color color)

--- a/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.iOS.cs
+++ b/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.iOS.cs
@@ -82,10 +82,10 @@ namespace dotMorten.Xamarin.Forms
             set => inputText.Placeholder = value;
         }
 
-		public bool IsSuggestionListOpen
+        public bool IsSuggestionListOpen
         {
             get => selectionList.Superview != null;
-			set
+            set
             {
                 if (value && selectionList.Superview == null && selectionList.Source != null && selectionList.Source.RowsInSection(selectionList, 0) > 0)
                 {
@@ -159,10 +159,10 @@ namespace dotMorten.Xamarin.Forms
             IsSuggestionListOpen = true;
         }
 
-		public string Text
+        public string Text
         {
             get => inputText.Text;
-			set
+            set
             {
                 suppressTextChangedEvent = true;
                 inputText.Text = value;
@@ -174,6 +174,11 @@ namespace dotMorten.Xamarin.Forms
         public void SetTextColor(global::Xamarin.Forms.Color color)
         {
             inputText.TextColor = global::Xamarin.Forms.Platform.iOS.ColorExtensions.ToUIColor(color);
+        }
+
+        public void SetPlaceHolderTextColor(global::Xamarin.Forms.Color color)
+        {
+            inputText.SetValueForKey(global::Xamarin.Forms.Platform.iOS.ColorExtensions.ToUIColor(color), new NSString("_placeholderLabel.textColor"));
         }
 
         public event EventHandler<AutoSuggestBoxTextChangedEventArgs> TextChanged;

--- a/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.iOS.cs
+++ b/AutoSuggestBox/dotMorten.Xamarin.Forms.AutoSuggestBox/NativeAutoSuggestBox.iOS.cs
@@ -1,15 +1,13 @@
 ﻿#if __IOS__
+using Foundation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using CoreGraphics;
-using Foundation;
 using UIKit;
 
 namespace dotMorten.Xamarin.Forms
 {
-    /// <summary>
+     /// <summary>
     ///  Extends AutoCompleteTextView to have similar APIs and behavior to UWP's AutoSuggestBox, which greatly simplifies wrapping it
     /// </summary>
     internal class NativeAutoSuggestBox : UIKit.UIView
@@ -80,6 +78,14 @@ namespace dotMorten.Xamarin.Forms
         {
             get => inputText.Placeholder;
             set => inputText.Placeholder = value;
+        }
+
+        public void SetPlaceHolderTextColor(global::Xamarin.Forms.Color color)
+        {
+            if (!string.IsNullOrEmpty(PlaceholderText))
+            {
+                inputText.AttributedPlaceholder = new NSAttributedString(new NSString(PlaceholderText), null, global::Xamarin.Forms.Platform.iOS.ColorExtensions.ToUIColor(color));
+            }
         }
 
         public bool IsSuggestionListOpen
@@ -174,11 +180,6 @@ namespace dotMorten.Xamarin.Forms
         public void SetTextColor(global::Xamarin.Forms.Color color)
         {
             inputText.TextColor = global::Xamarin.Forms.Platform.iOS.ColorExtensions.ToUIColor(color);
-        }
-
-        public void SetPlaceHolderTextColor(global::Xamarin.Forms.Color color)
-        {
-            inputText.SetValueForKey(global::Xamarin.Forms.Platform.iOS.ColorExtensions.ToUIColor(color), new NSString("_placeholderLabel.textColor"));
         }
 
         public event EventHandler<AutoSuggestBoxTextChangedEventArgs> TextChanged;


### PR DESCRIPTION
Added new properties PlaceHolderTextColor and the BackgroundTintColor only for android, doesn't apply within iOS. I added in focus changed to change the tint color but wasn't working. I may revisit this again, doesn't break anything. That code is there the property for the onFocus is not exposed in the PCL 